### PR TITLE
Update devcontainer and docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,11 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-	"name": "Alpine",
+	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:alpine-3.19",
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"GitHub.copilot",
-				"GitHub.copilot-chat"
-			]
-		}
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
@@ -20,7 +15,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+	// "postCreateCommand": "yarn install",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Node version: 20.11.1
 
 ```bash
 cp .env.example .env
-npm i
-npm run migrate
-npm run dev
+pnpm i
+pnpx supabase start
+pnpm run migrate
+pnpm run dev
 ```
 
 ## VS Code Extensions

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
         "supabase": "1.148.6",
         "ts-node": "10.9.2",
         "typescript": "5.4.2"
-    }
+    },
+    "packageManager": "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589"
 }


### PR DESCRIPTION
This makes the project runnable in GitHub Codespaces and devcontainers.

- Updated base devcontainer image to come preinstalled with Node.js v20 and Docker.
- Updated package.json to include `packageManager` set to `pnpm`.
- Updated docs to mention `supabase start` and use `pnpm` instead (from the presence of pnpm lockfile)